### PR TITLE
Fix coverage gaps for SP-stripped mature-only sequences (#23)

### DIFF
--- a/mhcseqs/domain_parsing.py
+++ b/mhcseqs/domain_parsing.py
@@ -759,6 +759,14 @@ class ParseScaffold:
             alpha1_len = self.groove_boundary - mature_start
             if alpha1_len > 0 and self.class_i_alpha2_len > 0:
                 g1, g2, total = _score_class_i_groove_lengths(alpha1_len, self.class_i_alpha2_len)
+                # SP-stripped mature-only sequences (pos=0, no Met) have
+                # truncated α1 because the SP and N-terminal residues are
+                # missing from the database deposit.  Cap the α1 length
+                # penalty so good Cys pair topology can still produce a
+                # viable parse.  This recovers horse Eqca, pig SLA, and
+                # similar IPD-MHC deposits.
+                if mature_start == 0 and self.seq[:1] != "M" and g1 < -3.0:
+                    g1 = -3.0
                 groove += g1 + g2 + total
             else:
                 groove += -80.0
@@ -3698,11 +3706,17 @@ def _enumerate_mature_starts(
     # enumeration.
     search_hi = min(search_hi, groove_end - 1)
 
-    if search_hi < search_lo:
-        return -1
-
     best_pos = -1
     best_score = -999.0
+
+    if search_hi < search_lo:
+        # No valid SP range.  For sequences that look SP-stripped (no Met,
+        # no h-region), fall through to the pos=0 check below — these are
+        # mature-only deposits where α1 is truncated (e.g., horse Eqca,
+        # pig SLA in IPD-MHC).  For Met-starting sequences, return -1 so
+        # the salvage path can try alternative Cys pairs.
+        if scaffold.seq[:1] == "M":
+            return -1
 
     for pos in range(search_lo, search_hi + 1):
         s = scaffold.score(pos)
@@ -3726,10 +3740,6 @@ def _enumerate_mature_starts(
             best_pos = pos
 
     # Also check pos=0 (SP-stripped / leaderless).
-    # The pos=0 candidate gets its groove/ig/tail scores from the scaffold
-    # normally, plus a leaderless bonus based on the same SP evidence used
-    # above (Met, h-region, charged N-terminus).  This ensures pos=0 and
-    # pos>0 compete on the same evidence model.
     s = scaffold.score(0)
 
     seq = scaffold.seq
@@ -4065,9 +4075,14 @@ def _refine_status(result: AlleleRecord) -> AlleleRecord:
 
     # Short groove detection: whichever groove segment(s) this grammar
     # actually owns must still be large enough to be functional.
+    # For SP-stripped sequences (mature_start=0, no Met), groove1 may be
+    # truncated because the N-terminal residues were missing from the
+    # database deposit.  Use a lower threshold (40 aa) for these.
+    is_sp_stripped = result.mature_start == 0 and not (result.sequence or "").startswith("M")
+    min_len = 40 if is_sp_stripped else MIN_FUNCTIONAL_GROOVE_HALF_LEN
     for field_name, _role in grammar.groove_segments:
         seg_len = int(getattr(result, f"{field_name}_len", 0) or 0)
-        if seg_len > 0 and seg_len < MIN_FUNCTIONAL_GROOVE_HALF_LEN:
+        if seg_len > 0 and seg_len < min_len:
             flags.append(f"{field_name}_short({seg_len})")
             return replace(result, status="short", flags=_flags_to_tuple(flags))
 

--- a/tests/test_groove.py
+++ b/tests/test_groove.py
@@ -302,13 +302,17 @@ def test_non_classical_mfsd_detected():
 
 
 def test_short_groove_class_i():
-    """A class I parse with groove1 < 70 aa should get status=short."""
-    # Truncate the mature sequence to produce a short groove1
-    # Remove first 30 residues — groove1 will be ~60 aa
-    truncated = HLA_A0201_MATURE[30:]
+    """A class I parse with groove1 < 70 aa should get status=short.
+
+    Note: SP-stripped sequences (no Met at position 0) get a relaxed
+    threshold (40 aa) because truncated N-terminal α1 domains are
+    common in IPD-MHC deposits.  This test uses a Met-starting sequence
+    to verify the normal 70 aa threshold.
+    """
+    # Prepend Met to the truncated sequence so the normal threshold applies
+    truncated = "M" + HLA_A0201_MATURE[31:]
     result = decompose_domains(truncated, mhc_class="I", allele="short-test", gene="A")
     if result.ok or result.status == "short":
-        # If it parsed at all, check the short detection
         if result.groove1_len > 0 and result.groove1_len < MIN_FUNCTIONAL_GROOVE_HALF_LEN:
             assert result.status == "short"
             assert any("groove1_short" in f for f in result.flags)


### PR DESCRIPTION
## Summary

Fixes horse (Eqca), pig (SLA), and chimpanzee (Patr) `missing_groove` failures from #23.
These are mature-only protein deposits in IPD-MHC where the signal peptide and first few
α1 residues are missing, giving a truncated α1 domain (55-65 aa instead of 80-95).

### Root cause

Three gates blocked parsing:
1. `_enumerate_mature_starts` returned -1 when the groove-derived search range was empty
   (α1=57 < hard_min=70 → no valid SP position → bail)
2. The groove-length prior gave -49 for α1=57 (beyond hard range), which the multiplicative
   gate turned into a near-zero score
3. `_refine_status` rejected groove halves < 70 aa as "short"

### Fix (general, not species-specific)

For SP-stripped sequences (mature_start=0, no Met):
- Fall through to pos=0 instead of returning -1 when search range is empty
- Cap α1 length penalty at -3.0 in `score_components`
- Lower short threshold to 40 aa in `_refine_status`

### Results

| Metric | Before | After |
|--------|--------|-------|
| Horse Eqca missing_groove | 19 | **0** |
| Pig SLA class I missing_groove | 12 | **5** |
| Patr-C missing_groove | 1 | **0** |
| FP SPs | 88 | **68** (−20 bonus!) |
| GT exact | 1,808 (82.4%) | 1,808 (82.4%) |
| Tests | 318 | 318 |

The FP reduction is a bonus: the α1 penalty cap makes pos=0 more competitive for
mature-only negative controls, correctly classifying them as leaderless.

### Not addressed in this PR
- Macaque J/K/L/S/W/G genes: these have len=1 in IPD-MHC (nucleotide-only, no protein)
- Macaque pseudogene lineages: same issue
- Rat Rano alleles: not in IPD-MHC protein database
- Remaining 5 SLA missing_groove: class II, different fix needed

Partially closes #23.