### PR TITLE
Refuse SP call when h-region is absent (leaderless gate)

### DIFF
--- a/mhcseqs/domain_parsing.py
+++ b/mhcseqs/domain_parsing.py
@@ -3955,6 +3955,18 @@ def refine_signal_peptide(
     ):
         return features.sp_shortcut_estimate
 
+    # Leaderless gate: every real-SP entry in the benchmark has a detectable
+    # h-region (≥6 aa).  When the h-region is absent and the sequence-level
+    # SP predictor also says 0, the Cys-pair-derived mature_start is almost
+    # certainly a false positive on a mature-only input — override to 0.
+    if (
+        features is not None
+        and (features.h_region[1] - features.h_region[0]) < 6
+        and features.sp_estimate == 0
+        and features.sp_shortcut_state != "sp_present"
+    ):
+        return 0
+
     group = _refinement_group(species_category)
     window = _REFINEMENT_WINDOW_BY_GROUP[group]
 

--- a/tests/test_groove.py
+++ b/tests/test_groove.py
@@ -806,6 +806,28 @@ def test_detect_h_region_no_sp():
         assert h_start > 5 or h_end - h_start < 10
 
 
+def test_refine_signal_peptide_rejects_mature_only_input():
+    """When the sequence has no detectable h-region and the sequence-level
+    predictor says no SP, the Cys-pair-derived mature_start must be
+    overridden to 0. Regression: a mature-only HLA-DMA fragment was
+    getting SP=24 called before this gate.
+    """
+    from mhcseqs.domain_parsing import analyze_sequence, refine_signal_peptide
+
+    mature_only_dma = "VPEAPTPMWPDDLQNHTFLHTVYCQDGSPSVGLSEAYDEDQLFFFDFSQNTRVPRLPEFADWAQEQGDAPAILFDKEFCEWMIQQIGPKLDGKIPVSRGFPIAEVFTLKPL"
+    features = analyze_sequence(mature_only_dma)
+    assert features.h_region[1] - features.h_region[0] < 6
+    assert features.sp_estimate == 0
+    # Simulate a Cys-pair-derived mature_start that the gate must override.
+    assert refine_signal_peptide(mature_only_dma, 24, "human", "II", features=features) == 0
+
+    # Positive control: real SP should still refine to a positive position.
+    hla_a_full = "MAVMAPRTLLLLLSGALALTQTWA" + HLA_A0201_MATURE
+    real_features = analyze_sequence(hla_a_full)
+    refined = refine_signal_peptide(hla_a_full, 24, "human", "I", features=real_features)
+    assert refined > 0
+
+
 def test_estimate_sp_from_h_region():
     """SP estimate from h-region should be close to true SP length."""
     hla_a_full = "MAVMAPRTLLLLLSGALALTQTWA" + HLA_A0201_MATURE


### PR DESCRIPTION
## Summary

`refine_signal_peptide` accepted any Cys-pair-derived `mature_start > 0` and only refined its position. For mature-only controls (sequences that really have no SP), the Cys-pair anchor could still produce a positive `mature_start`, which the refiner locked in — responsible for 12 of the remaining 47 negative-control false positives.

## Why this is safe

Empirical check across the benchmark (all three GT + NC files):

| Corpus | Entries | Entries with h-region length < 6 |
|---|---|---|
| Real-SP GT | 2402 | **0** |
| Mature-only NC | 2155 | 598 (28%) |

**Zero** real signal peptides in the benchmark have an h-region shorter than 6 residues. This matches signal-peptidase biophysics — SPase needs an extended hydrophobic core upstream of the cleavage site. So the absence of an h-region is a reliable negative signal.

## The gate

In `refine_signal_peptide`, when **all** of:
- h-region length < 6
- sequence-level SP predictor returned 0 (`features.sp_estimate == 0`)
- no exact-prefix SP shortcut is forcing `sp_present`

return 0 regardless of the Cys-pair anchor.

Biophysics-driven, not a special case — anything that gets caught here has no hydrophobic core and no sequence-cue evidence for SP.

## Impact

| Metric | Before | After |
|---|---|---|
| Negative-control false-positive SPs | 47 | **35** (-26%) |
| SP exact match | 84.4% | 84.4% (unchanged) |
| Tests | 330 | 331 |

Cumulative since the start of this release train: NC FPs **82 → 35** (-57%).

## Test plan

- [x] `test_refine_signal_peptide_rejects_mature_only_input` (new) — covers both the rejection and a positive control (real HLA-A SP still refines to >0)
- [x] 331/331 tests passing
- [x] `evaluate_sp_ground_truth.py` — 84.4% exact (no regression)
- [x] `evaluate_sp_negative_controls.py` — 35 FPs